### PR TITLE
add page-header  css background

### DIFF
--- a/components/page-header/style/index.less
+++ b/components/page-header/style/index.less
@@ -8,6 +8,7 @@
 
   position: relative;
   padding: @page-header-padding;
+  background: @component-background;
 
   &.has-breadcrumb {
     padding-top: @page-header-padding-breadcrumb;


### PR DESCRIPTION
add page-header  css background

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution

上一版本的 PageHeader 是自带白色背景的，更新到 v3.23.1 颜色就没有了。所以把白色背景补回来

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     add page-header  css background      |
| 🇨🇳 Chinese |    给 PageHeader 添加背景色       |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
